### PR TITLE
fix: Removing unnecessary prefix from WithStartParameter

### DIFF
--- a/src/Topshelf.StartParameters/StartParametersExtensions.cs
+++ b/src/Topshelf.StartParameters/StartParametersExtensions.cs
@@ -6,8 +6,6 @@ namespace Topshelf.StartParameters
 {
     public static class StartParametersExtensions
     {
-        private const string Prefix = "tssp";
-
         private static readonly Dictionary<HostConfigurator, List<Tuple<string, string>>> ActionTable =
             new Dictionary<HostConfigurator, List<Tuple<string, string>>>();
 
@@ -18,28 +16,28 @@ namespace Topshelf.StartParameters
         }
 
         public static HostConfigurator WithStartParameter(this HostConfigurator configurator, string name,
-            Action<string> action)
+                                                          Action<string> action)
         {
-            configurator.AddCommandLineDefinition(Prefix + name, action);
-            configurator.AddCommandLineDefinition(name, s => Add(configurator, Prefix + name, s));
+            configurator.AddCommandLineDefinition(name, action);
+            configurator.AddCommandLineDefinition(name, s => Add(configurator, name, s));
 
             return configurator;
         }
 
-        public static HostConfigurator WithCustomStartParameter(this HostConfigurator configurator, string argName,string paramName,
-    Action<string> action)
+        public static HostConfigurator WithStartParameter(this HostConfigurator configurator, string name, string value,
+                                                          Action<string> action)
+        {
+            Add(configurator, name, value);
+            configurator.AddCommandLineDefinition(name, action);
+
+            return configurator;
+        }
+
+        public static HostConfigurator WithCustomStartParameter(this HostConfigurator configurator, string argName,
+                                                                string paramName, Action<string> action)
         {
             configurator.AddCommandLineDefinition(paramName, action);
             configurator.AddCommandLineDefinition(argName, s => Add(configurator, paramName, s));
-
-            return configurator;
-        }
-
-        public static HostConfigurator WithStartParameter(this HostConfigurator configurator, string name,string value,
-    Action<string> action)
-        {
-            Add(configurator,name,value);
-            configurator.AddCommandLineDefinition(name, action);
 
             return configurator;
         }
@@ -62,6 +60,6 @@ namespace Topshelf.StartParameters
             ActionTable.TryGetValue(configurator, out pairs);
 
             return pairs;
-        } 
+        }
     }
 }


### PR DESCRIPTION
Addressing the issue raised here: https://github.com/r1pper/Topshelf.StartParameters/issues/5

Looks like only one of the extension methods were adding the prefix, seems to make sense to remove the prefix for clarity and consistency. I was certainly surprised to find the prefix added to all of my parameters.